### PR TITLE
Added .json extension to require statement in index.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.1 (2018-07-24)
+
+- Changed require for states to include json extension. 
+
 ## 1.1.0 (2018-01-17)
 
 - Add Puerto Rico (PR)

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var _ = require('lodash');
 
-var stateNamesByCode = require('./states');
+var stateNamesByCode = require('./states.json');
 var stateCodesByName = _.invert(stateNamesByCode);
 
 // normalizes case and removes invalid characters


### PR DESCRIPTION
First off, awesome module. I was able to use this quite seamlessly in a project for work.

In order for node to correctly parse the json file the extension is required. This was causing a build failure with the message that ./states could not be found

This may have worked for previous versions of node. It doesn't for v10.4.1

 ./states.json in the require statement is the fix implemented.
