### PR TITLE
Replace lodash dependencies with native code

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,40 +1,52 @@
 function invert(obj) {
   return Object.entries(obj).reduce(function (acc, entry) {
-    return {...acc, [entry.name]: entry.code};
+    var code = entry[0];
+    var name = entry[1];
+    acc[name] = code;
+    return acc;
   }, {});
 }
 
 function isString(val) {
-  return typeof val === 'string'
+  return typeof val === "string";
 }
 
-var stateNamesByCode = require('./states.json');
+var stateNamesByCode = require("./states.json");
 var stateCodesByName = invert(stateNamesByCode);
 
 // normalizes case and removes invalid characters
 // returns null if can't find sanitized code in the state map
-var sanitizeStateCode = function(code) {
-  code = isString(code) ? code.trim().toUpperCase().replace(/[^A-Z]/g, '') : null;
+var sanitizeStateCode = function (code) {
+  code = isString(code)
+    ? code
+        .trim()
+        .toUpperCase()
+        .replace(/[^A-Z]/g, "")
+    : null;
   return stateNamesByCode[code] ? code : null;
 };
 
 // returns a valid state name else null
-var getStateNameByStateCode = function(code) {
+var getStateNameByStateCode = function (code) {
   return stateNamesByCode[sanitizeStateCode(code)] || null;
 };
 
 // normalizes case and removes invalid characters
 // returns null if can't find sanitized name in the state map
-var sanitizeStateName = function(name) {
+var sanitizeStateName = function (name) {
   if (!isString(name)) {
     return null;
   }
 
   // bad whitespace remains bad whitespace e.g. "O  hi o" is not valid
-  name = name.trim().toLowerCase().replace(/[^a-z\s]/g, '').replace(/\s+/g, ' ');
+  name = name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z\s]/g, "")
+    .replace(/\s+/g, " ");
 
   var tokens = name.split(/\s+/);
-  tokens = tokens.map(function(token) {
+  tokens = tokens.map(function (token) {
     return token.charAt(0).toUpperCase() + token.slice(1);
   });
 
@@ -43,12 +55,12 @@ var sanitizeStateName = function(name) {
     tokens[1] = tokens[1].toLowerCase();
   }
 
-  name = tokens.join(' ');
+  name = tokens.join(" ");
   return stateCodesByName[name] ? name : null;
 };
 
 // returns a valid state code else null
-var getStateCodeByStateName = function(name) {
+var getStateCodeByStateName = function (name) {
   return stateCodesByName[sanitizeStateName(name)] || null;
 };
 
@@ -57,5 +69,5 @@ module.exports = {
   getStateNameByStateCode: getStateNameByStateCode,
 
   sanitizeStateName: sanitizeStateName,
-  getStateCodeByStateName: getStateCodeByStateName
+  getStateCodeByStateName: getStateCodeByStateName,
 };

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 function invert(obj) {
-  return Object.entries(obj).reduce((acc, [code, name]) => ({...acc, [name]: code}))
+  return Object.entries(obj).reduce(function (acc, entry) {
+    return {...acc, [entry.name]: entry.code};
+  }, {});
 }
 
 function isString(val) {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,10 @@
-var map = require('lodash.map');
-var invert = require('lodash.invert');
-var isString = require('lodash.isstring');
+function invert(obj) {
+  return Object.entries(obj).reduce((acc, [code, name]) => ({...acc, [name]: code}))
+}
+
+function isString(val) {
+  return typeof val === 'string'
+}
 
 var stateNamesByCode = require('./states.json');
 var stateCodesByName = invert(stateNamesByCode);
@@ -28,7 +32,7 @@ var sanitizeStateName = function(name) {
   name = name.trim().toLowerCase().replace(/[^a-z\s]/g, '').replace(/\s+/g, ' ');
 
   var tokens = name.split(/\s+/);
-  tokens = map(tokens, function(token) {
+  tokens = tokens.map(function(token) {
     return token.charAt(0).toUpperCase() + token.slice(1);
   });
 

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ function invert(obj) {
 }
 
 function isString(val) {
-  return typeof val === 'string'
+  return typeof val === 'string';
 }
 
 var stateNamesByCode = require('./states.json');

--- a/index.js
+++ b/index.js
@@ -8,45 +8,36 @@ function invert(obj) {
 }
 
 function isString(val) {
-  return typeof val === "string";
+  return typeof val === 'string'
 }
 
-var stateNamesByCode = require("./states.json");
+var stateNamesByCode = require('./states.json');
 var stateCodesByName = invert(stateNamesByCode);
 
 // normalizes case and removes invalid characters
 // returns null if can't find sanitized code in the state map
-var sanitizeStateCode = function (code) {
-  code = isString(code)
-    ? code
-        .trim()
-        .toUpperCase()
-        .replace(/[^A-Z]/g, "")
-    : null;
+var sanitizeStateCode = function(code) {
+  code = isString(code) ? code.trim().toUpperCase().replace(/[^A-Z]/g, '') : null;
   return stateNamesByCode[code] ? code : null;
 };
 
 // returns a valid state name else null
-var getStateNameByStateCode = function (code) {
+var getStateNameByStateCode = function(code) {
   return stateNamesByCode[sanitizeStateCode(code)] || null;
 };
 
 // normalizes case and removes invalid characters
 // returns null if can't find sanitized name in the state map
-var sanitizeStateName = function (name) {
+var sanitizeStateName = function(name) {
   if (!isString(name)) {
     return null;
   }
 
   // bad whitespace remains bad whitespace e.g. "O  hi o" is not valid
-  name = name
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z\s]/g, "")
-    .replace(/\s+/g, " ");
+  name = name.trim().toLowerCase().replace(/[^a-z\s]/g, '').replace(/\s+/g, ' ');
 
   var tokens = name.split(/\s+/);
-  tokens = tokens.map(function (token) {
+  tokens = tokens.map(function(token) {
     return token.charAt(0).toUpperCase() + token.slice(1);
   });
 
@@ -55,12 +46,12 @@ var sanitizeStateName = function (name) {
     tokens[1] = tokens[1].toLowerCase();
   }
 
-  name = tokens.join(" ");
+  name = tokens.join(' ');
   return stateCodesByName[name] ? name : null;
 };
 
 // returns a valid state code else null
-var getStateCodeByStateName = function (name) {
+var getStateCodeByStateName = function(name) {
   return stateCodesByName[sanitizeStateName(name)] || null;
 };
 
@@ -69,5 +60,5 @@ module.exports = {
   getStateNameByStateCode: getStateNameByStateCode,
 
   sanitizeStateName: sanitizeStateName,
-  getStateCodeByStateName: getStateCodeByStateName,
+  getStateCodeByStateName: getStateCodeByStateName
 };

--- a/package.json
+++ b/package.json
@@ -23,11 +23,7 @@
     "url": "https://github.com/mdzhang/us-state-codes/issues"
   },
   "homepage": "https://github.com/mdzhang/us-state-codes#readme",
-  "dependencies": {
-    "lodash.invert": "^4.3.0",
-    "lodash.isstring": "^4.0.1",
-    "lodash.map": "^4.6.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "chai": "^4.2.0",
     "mocha": "^6.0.0"


### PR DESCRIPTION
I would like to use this library on the front-end for parsing USA State abreviations & names, but the 5.5kB (minified & gzipped) size is too large to justify the inclusion.

This PR removes all 3rd party dependencies and replaces them with Javascript built-in functions. ~92% of the npm package's size was from lodash dependencies.

Analysis from https://bundlephobia.com/package/us-state-codes@1.1.2.

All tests passed locally, so I do not believe I've made any inappropriate assumptions about the library's data types.